### PR TITLE
Return TypeScript Version in the Compile Result

### DIFF
--- a/src/AppsCompiler.ts
+++ b/src/AppsCompiler.ts
@@ -96,7 +96,13 @@ export class AppsCompiler {
 
         const startTime = Date.now();
 
-        const result: ICompilerResult = { files, implemented: [], diagnostics: [], duration: NaN };
+        const result: ICompilerResult = {
+            files,
+            implemented: [],
+            diagnostics: [],
+            duration: NaN,
+            typeScriptVersion: this.ts.version,
+        };
 
         // Verify all file names are normalized
         // and that the files are valid

--- a/src/definition/ICompilerResult.ts
+++ b/src/definition/ICompilerResult.ts
@@ -8,4 +8,5 @@ export interface ICompilerResult {
     implemented: Array<string>;
     diagnostics: Array<ICompilerDiagnostic>;
     duration: number;
+    typeScriptVersion: string;
 }


### PR DESCRIPTION
This way we can display what version of TypeScript was used to compile in case the diagnostic errors don't give any indication of what is going on or we somehow compile with an older version of TypeScript. Gives us more insight into what is happenig.