### PR TITLE
Improve handling of modules no found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocket.chat/apps-compiler",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -179,9 +179,9 @@
       }
     },
     "@rocket.chat/apps-engine": {
-      "version": "1.18.0-alpha.3754",
-      "resolved": "https://registry.npmjs.org/@rocket.chat/apps-engine/-/apps-engine-1.18.0-alpha.3754.tgz",
-      "integrity": "sha512-R8TsCtQ9s63YfofHkNs9MucXPXAcz8lhHi0t1CF3nJPyg5Nh93Hgq0kktqqQE6Awd/fWgMBDX46S83x8JHgLFg==",
+      "version": "1.19.0-alpha.4006",
+      "resolved": "https://registry.npmjs.org/@rocket.chat/apps-engine/-/apps-engine-1.19.0-alpha.4006.tgz",
+      "integrity": "sha512-0OczVTVa9ZGqIlCoKSYhT3AuPwlnRPkOsPApk5L3Dx667Ch6VSpsjur8WPbRDfLR8T/XNIs026RMVIu0DxA9kQ==",
       "requires": {
         "adm-zip": "^0.4.9",
         "cryptiles": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rocket.chat/apps-compiler",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "The Rocket.Chat apps compiler",
     "main": "index.js",
     "scripts": {
@@ -50,7 +50,7 @@
         "ts-node": "^8.10.2"
     },
     "dependencies": {
-        "@rocket.chat/apps-engine": "^1.18.0-alpha.3754",
+        "@rocket.chat/apps-engine": "^1.19.0-alpha.4006",
         "figures": "^3.0.0",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.4",

--- a/src/AppsCompiler.ts
+++ b/src/AppsCompiler.ts
@@ -176,12 +176,14 @@ export class AppsCompiler {
                 throw new Error(`Language Service's Compiler Options Diagnostics contains ${ coDiag.length } diagnostics.`);
             }
         } catch (e) {
-            if (e.message === 'Debug Failure. False expression.') {
+            if (modulesNotFound.length !== 0) {
                 result.diagnostics = modulesNotFound;
                 result.duration = Date.now() - startTime;
 
                 return result;
             }
+
+            throw e;
         }
 
         const src = languageService.getProgram().getSourceFile(appInfo.classFile);

--- a/src/compiler/getAppSource.ts
+++ b/src/compiler/getAppSource.ts
@@ -1,11 +1,10 @@
 import { readdir, readFile } from 'fs';
 import { normalize, resolve } from 'path';
 import { promisify } from 'util';
-import { IAppSource } from '../definition';
+import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
 
-import { IAppInfo } from '../definition/IAppInfo';
-import { ICompilerFile } from '../definition/ICompilerFile';
-import { IMapCompilerFile } from '../definition/IMapCompilerFile';
+
+import { IAppSource, ICompilerFile, IMapCompilerFile } from '../definition';
 
 const readdirPromise = promisify(readdir);
 const readfilePromise = promisify(readFile);
@@ -68,8 +67,7 @@ function getAppInfo(projectFiles: ICompilerFile[]): IAppInfo {
     }
 
     try {
-        const { name, version, classFile } = JSON.parse(appJson.content);
-        return { name, version, classFile };
+        return JSON.parse(appJson.content) as IAppInfo;
     } catch (error) {
         throw new Error('app.json parsing fail');
     }

--- a/src/definition/IAppInfo.ts
+++ b/src/definition/IAppInfo.ts
@@ -1,5 +1,0 @@
-export interface IAppInfo {
-    name: string;
-    version?: string;
-    classFile: string;
-}

--- a/src/definition/IAppSource.ts
+++ b/src/definition/IAppSource.ts
@@ -1,5 +1,6 @@
+import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
+
 import { ICompilerFile } from './ICompilerFile';
-import { IAppInfo } from './IAppInfo';
 
 export interface IAppSource {
     appInfo: IAppInfo;

--- a/src/definition/index.ts
+++ b/src/definition/index.ts
@@ -1,4 +1,3 @@
-import { IAppInfo } from './IAppInfo';
 import { IAppSource } from './IAppSource';
 import { ICompilerDescriptor } from './ICompilerDescriptor';
 import { ICompilerDiagnostic } from './ICompilerDiagnostic';
@@ -11,7 +10,6 @@ import { CompilerFileNotFoundError } from './CompilerFileNotFoundError';
 
 export {
     CompilerFileNotFoundError,
-    IAppInfo,
     IAppSource,
     ICompilerDescriptor,
     ICompilerDiagnostic,

--- a/src/misc/appPackager.ts
+++ b/src/misc/appPackager.ts
@@ -49,12 +49,10 @@ export class AppPackager {
     }
 
     private overwriteAppManifest(): void {
-        const i = this.fd.info as any;
+        this.fd.info.implements = this.compiledApp.getImplemented()
+            .filter((interfaceName) => !!AppInterface[interfaceName as AppInterface]) as Array<AppInterface>;
 
-        i.implements = this.compiledApp.getImplemented().filter((interfaceName) => !!AppInterface[interfaceName as AppInterface]) as Array<AppInterface>;
-        this.fd.info = i;
-
-        fs.writeFileSync(this.fd.infoFile, JSON.stringify(i, null, 4));
+        fs.writeFileSync(this.fd.infoFile, JSON.stringify(this.fd.info, null, 4));
     }
 
     private async zipSupportFiles(): Promise<void> {

--- a/src/misc/appPackager.ts
+++ b/src/misc/appPackager.ts
@@ -49,10 +49,12 @@ export class AppPackager {
     }
 
     private overwriteAppManifest(): void {
-        this.fd.info.implements = this.compiledApp.getImplemented()
-            .filter((interfaceName) => !!AppInterface[interfaceName as AppInterface]) as Array<AppInterface>;
+        const i = this.fd.info as any;
 
-        fs.writeFileSync(this.fd.infoFile, JSON.stringify(this.fd.info, null, 4));
+        i.implements = this.compiledApp.getImplemented().filter((interfaceName) => !!AppInterface[interfaceName as AppInterface]) as Array<AppInterface>;
+        this.fd.info = i;
+
+        fs.writeFileSync(this.fd.infoFile, JSON.stringify(i, null, 4));
     }
 
     private async zipSupportFiles(): Promise<void> {


### PR DESCRIPTION
We now better handle when an app uses a module not found. Also, removed the `IAppInfo` from being defined in this repo as having this defined in more than one place creates confusion and also means we have to update the definition in several places if it ever changes.