### PR TITLE
[FIX] Remove the unnecessay implements filter

### DIFF
--- a/src/misc/appPackager.ts
+++ b/src/misc/appPackager.ts
@@ -49,9 +49,7 @@ export class AppPackager {
     }
 
     private overwriteAppManifest(): void {
-        this.fd.info.implements = this.compiledApp.getImplemented()
-            .filter((interfaceName) => !!AppInterface[interfaceName as AppInterface]) as Array<AppInterface>;
-
+        this.fd.info.implements = this.compiledApp.getImplemented();
         fs.writeFileSync(this.fd.infoFile, JSON.stringify(this.fd.info, null, 4));
     }
 


### PR DESCRIPTION
We already do similar work on the apps-engine side. We shouldn't filter them here, since it adds an unnecessay dependency on the apps-engine's version.