### PR TITLE
[FIX] Missing support to symbolic links in the app's files structure

### DIFF
--- a/src/compiler/getAppSource.ts
+++ b/src/compiler/getAppSource.ts
@@ -21,7 +21,7 @@ async function walkDirectory(directory: string): Promise<ICompilerFile[]> {
                     return null;
                 }
 
-                if (dirent.isDirectory()) {
+                if (dirent.isDirectory() || dirent.isSymbolicLink()) {
                     return walkDirectory(res);
                 }
 


### PR DESCRIPTION
# What? :boat:
 - Add support to symbolic links in the app's files strucuture, avoiding the EISDIR error previously thrown in these scenarios.

# Why? :thinking:
Fixes issue #26.

# Links :earth_americas:
[Issue - ClickUp](https://app.clickup.com/t/396duu).