### PR TITLE
Fix require of Apps-Engine paths for compiled app

### DIFF
--- a/src/AppsCompiler.ts
+++ b/src/AppsCompiler.ts
@@ -408,7 +408,7 @@ export class AppsCompiler {
             require: (filepath: string) => {
                 // Handles Apps-Engine import
                 if (filepath.startsWith('@rocket.chat/apps-engine/definition/')) {
-                    return require(`${ this.wd }/node_modules/${ filepath }.js`);
+                    return require(`${ this.wd }/node_modules/${ filepath }`);
                 }
 
                 // Handles native node modules import


### PR DESCRIPTION
Previous require appended `.js` to Apps-Engine requires, which prevented folder requires, e.g. `@rocket.chat/apps-engine/definition/settings`