### PR TITLE
[FIX] Make sure the compiler only changes the last `.ts` in a filename

### DIFF
--- a/src/AppsCompiler.ts
+++ b/src/AppsCompiler.ts
@@ -240,7 +240,7 @@ export class AppsCompiler {
             const file: ICompilerFile = result.files[key];
             const output: EmitOutput = languageService.getEmitOutput(file.name);
 
-            file.name = key.replace(/\.ts/g, '.js');
+            file.name = key.replace(/\.ts$/g, '.js');
 
             delete result.files[key];
             result.files[file.name] = file;


### PR DESCRIPTION
**TL;DR** - this pull request adds a `$` to the file renaming regex, making it only replace the last instance of `.ts` in a given file's name, so imports won't break because of unusual file names.

In the current implementation, one of the steps of the compilation process is the renaming of `.ts` files' extension to `.js`. It is running the string replace method with the following arguments: `<string>.replace(/\.ts/g, '.js')`.

The problem this line might create is that in the eventuality of a filename that has more than one `.ts` in it, it will change every instance of it to `.js`. As a result, any reference to this file by `require/import` statements will return undefined because now the filename is incorrect in the strings passed to them.

Example:

Say there's the file slashcommand/alert.ts.ts (for some reason it got named like this, it does not concern us). Importing this in a module would be as follows:
```javascript
import * from 'slashcommand/alert.ts';
```
This is because what matters is the last `.ts`. The rest is part of the name.

After compilation, the argument used to importing `alert` won't change, but because we used the regex `/\.ts/g`, the two instances of `.ts` got renamed, making the import (now, `require`) returning undefined because the file got renamed incorrectly to `slashcommand/alert.js.js`.

By adding the `$` matcher at the end of the regex, we ensure only the last `.ts` in the filename gets renamed, not breaking any references to the file in the app's source code.