### PR TITLE
[NEW] Introduce Rollup

### DIFF
--- a/src/AppsCompiler.ts
+++ b/src/AppsCompiler.ts
@@ -1,106 +1,48 @@
 import * as fs from 'fs';
-import * as vm from 'vm';
-import * as path from 'path';
 import * as fallbackTypescript from 'typescript';
-import {
-    CompilerOptions, Diagnostic, EmitOutput,
-    HeritageClause, LanguageServiceHost,
-    ModuleResolutionHost, ResolvedModule,
-} from 'typescript';
 
 import { createRequire } from 'module';
-import { Omit } from './misc/util';
 import { getAppSource } from './compiler/getAppSource';
-import { IAppSource, ICompilerDescriptor, ICompilerFile, ICompilerResult, IMapCompilerFile, IFiles } from './definition';
-import { Utilities } from './misc/Utilities';
+import { ICompilerDescriptor, ICompilerResult } from './definition';
 import { FolderDetails } from './misc/folderDetails';
 import { AppPackager } from './misc/appPackager';
-import { ICompilerDiagnostic } from './definition/ICompilerDiagnostic';
-import { IPermission } from './definition/IPermission';
-import { getAvailablePermissions } from './misc/getAvailablePermissions';
+import { TypescriptCompiler } from './compiler/TypescriptCompiler';
+import { AppsEngineValidator } from './compiler/AppsEngineValidator';
 
-type TypeScript = typeof fallbackTypescript;
+export type TypeScript = typeof fallbackTypescript;
 
 export class AppsCompiler {
-    private readonly compilerOptions: CompilerOptions;
+    private compilationResult: ICompilerResult | undefined;
 
-    private libraryFiles: IMapCompilerFile;
+    private readonly validator: AppsEngineValidator;
 
-    private compiled: IFiles;
-
-    private implemented: string[];
-
-    private wd: string;
-
-    private _appRequire: NodeRequire;
+    private readonly typescriptCompiler: TypescriptCompiler;
 
     constructor(
         private readonly compilerDesc: ICompilerDescriptor,
-        private readonly ts: TypeScript = fallbackTypescript,
+        private readonly sourcePath: string,
+        ts: TypeScript = fallbackTypescript,
     ) {
-        this.compilerOptions = {
-            target: this.ts.ScriptTarget.ES2017,
-            module: this.ts.ModuleKind.CommonJS,
-            moduleResolution: this.ts.ModuleResolutionKind.NodeJs,
-            declaration: false,
-            noImplicitAny: false,
-            removeComments: true,
-            strictNullChecks: true,
-            noImplicitReturns: true,
-            emitDecoratorMetadata: true,
-            experimentalDecorators: true,
-            types: ['node'],
-            // Set this to true if you would like to see the module resolution process
-            traceResolution: false,
-        };
-        this.libraryFiles = {};
+        this.validator = new AppsEngineValidator(createRequire(`${ sourcePath }/app.json`));
+
+        this.typescriptCompiler = new TypescriptCompiler(sourcePath, ts, this.validator);
     }
 
-    /**
-    * Requires a module from the app's node_modules directory
-    *
-    * @param id {string} The id of the module
-     */
-    public get appRequire(): NodeRequire {
-        return this._appRequire;
+    public getLatestCompilationResult(): AppsCompiler['compilationResult'] {
+        return this.compilationResult;
     }
 
-    public async compile(path: string): Promise<ICompilerResult> {
-        this.wd = path;
-        this._appRequire = createRequire(`${ path }/app.json`);
+    public async compile(): Promise<ICompilerResult> {
+        const source = await getAppSource(this.sourcePath);
 
-        const source = await getAppSource(path);
+        this.compilationResult = this.typescriptCompiler.transpileSource(source);
 
-        // Pre compilation validations
-        this.validateAppPermissionsSchema(source.appInfo.permissions);
-
-        const compilerResult = this.toJs(source);
-        const { files, implemented } = compilerResult;
-        const { permissions } = source.appInfo;
-
-        this.validateAppPermissionsSchema(permissions);
-
-        this.compiled = Object.entries(files)
-            .map(([, { name, compiled }]) => ({ [name]: compiled }))
-            .reduce((acc, cur) => Object.assign(acc, cur), {});
-        this.implemented = implemented;
-
-        // Post compilation validations
-        this.checkInheritance(source.appInfo.classFile.replace(/\.ts$/, ''));
-
-        return Object.assign(compilerResult, { permissions });
-    }
-
-    public output(): IFiles {
-        return this.compiled;
-    }
-
-    public getImplemented(): string[] {
-        return this.implemented;
+        return this.getLatestCompilationResult();
     }
 
     public async outputZip(outputPath: string): Promise<Buffer> {
-        const fd = new FolderDetails(this.wd);
+        const fd = new FolderDetails(this.sourcePath);
+
         try {
             // @NOTE this is important for generating the zip file with the correct name
             await fd.readInfoFile();
@@ -109,339 +51,14 @@ export class AppsCompiler {
             return;
         }
 
-        const packager = new AppPackager(this.compilerDesc, fd, this, outputPath);
+        const compilationResult = this.getLatestCompilationResult();
+
+        if (!compilationResult) {
+            throw new Error('No compilation data found');
+        }
+
+        const packager = new AppPackager(this.compilerDesc, fd, compilationResult, outputPath);
+
         return fs.promises.readFile(await packager.zipItUp());
-    }
-
-    private validateAppPermissionsSchema(permissions: Array<IPermission>): void {
-        if (!permissions) {
-            return;
-        }
-
-        if (!Array.isArray(permissions)) {
-            throw new Error('Invalid permission definition. Check your manifest file.');
-        }
-
-        const permissionsRequire = this.appRequire('@rocket.chat/apps-engine/server/permissions/AppPermissions');
-
-        if (!permissionsRequire || !permissionsRequire.AppPermissions) {
-            return;
-        }
-
-        const availablePermissions = getAvailablePermissions(permissionsRequire.AppPermissions);
-
-        permissions.forEach((permission) => {
-            if (permission && !availablePermissions.includes(permission.name)) {
-                throw new Error(`Invalid permission "${ String(permission.name) }" defined. Check your manifest file`);
-            }
-        });
-    }
-
-    private toJs({ appInfo, sourceFiles: files }: IAppSource): Omit<ICompilerResult, 'permissions'> {
-        if (!appInfo.classFile || !files[appInfo.classFile] || !this.isValidFile(files[appInfo.classFile])) {
-            throw new Error(`Invalid App package. Could not find the classFile (${ appInfo.classFile }) file.`);
-        }
-
-        const startTime = Date.now();
-
-        const result: Omit<ICompilerResult, 'permissions'> = {
-            files,
-            implemented: [],
-            diagnostics: [],
-            duration: NaN,
-            name: appInfo.name,
-            version: appInfo.version,
-            typeScriptVersion: this.ts.version,
-        };
-
-        // Verify all file names are normalized
-        // and that the files are valid
-        Object.keys(result.files).forEach((key) => {
-            if (!this.isValidFile(result.files[key])) {
-                throw new Error(`Invalid TypeScript file: "${ key }".`);
-            }
-
-            result.files[key].name = path.normalize(result.files[key].name);
-        });
-
-        const modulesNotFound: ICompilerDiagnostic[] = [];
-        const host = {
-            getScriptFileNames: () => Object.keys(result.files),
-            getScriptVersion: (fileName) => {
-                fileName = path.normalize(fileName);
-                const file = result.files[fileName] || this.getLibraryFile(fileName);
-                return file && file.version.toString();
-            },
-            getScriptSnapshot: (fileName) => {
-                fileName = path.normalize(fileName);
-                const file = result.files[fileName] || this.getLibraryFile(fileName);
-
-                if (!file || !file.content) {
-                    return;
-                }
-
-                return this.ts.ScriptSnapshot.fromString(file.content);
-            },
-            getCompilationSettings: () => this.compilerOptions,
-            getCurrentDirectory: () => this.wd,
-            getDefaultLibFileName: () => this.ts.getDefaultLibFilePath(this.compilerOptions),
-            fileExists: (fileName: string): boolean => this.ts.sys.fileExists(fileName),
-            readFile: (fileName: string): string | undefined => this.ts.sys.readFile(fileName),
-            resolveModuleNames: (moduleNames: Array<string>, containingFile: string): Array<ResolvedModule> => {
-                const resolvedModules: ResolvedModule[] = [];
-                const moduleResHost: ModuleResolutionHost = {
-                    fileExists: host.fileExists, readFile: host.readFile, trace: (traceDetail) => console.log(traceDetail),
-                };
-
-                for (const moduleName of moduleNames) {
-                    const index = this.resolver(moduleName, resolvedModules, containingFile, result, this.wd, moduleResHost);
-                    if (index === -1) {
-                        modulesNotFound.push({
-                            filename: containingFile,
-                            line: 0,
-                            character: 0,
-                            lineText: '',
-                            message: `Failed to resolve module: ${ moduleName }`,
-                            originalMessage: `Module not found: ${ moduleName }`,
-                            originalDiagnostic: undefined,
-                        });
-                    }
-                }
-
-                return resolvedModules;
-            },
-        } as LanguageServiceHost;
-
-        const languageService = this.ts.createLanguageService(host, this.ts.createDocumentRegistry());
-
-        try {
-            const coDiag = languageService.getCompilerOptionsDiagnostics();
-            if (coDiag.length !== 0) {
-                console.log(coDiag);
-
-                console.error('A VERY UNEXPECTED ERROR HAPPENED THAT SHOULD NOT!');
-                // console.error('Please report this error with a screenshot of the logs. ' +
-                //     `Also, please email a copy of the App being installed/updated: ${ info.name } v${ info.version } (${ info.id })`);
-
-                throw new Error(`Language Service's Compiler Options Diagnostics contains ${ coDiag.length } diagnostics.`);
-            }
-        } catch (e) {
-            if (modulesNotFound.length !== 0) {
-                result.diagnostics = modulesNotFound;
-                result.duration = Date.now() - startTime;
-
-                return result;
-            }
-
-            throw e;
-        }
-
-        const src = languageService.getProgram().getSourceFile(appInfo.classFile);
-
-        this.ts.forEachChild(src, (n) => {
-            if (!this.ts.isClassDeclaration(n)) return;
-
-            this.ts.forEachChild(n, (node) => {
-                if (this.ts.isHeritageClause(node)) {
-                    const e = node as HeritageClause;
-
-                    this.ts.forEachChild(node, (nn) => {
-                        if (e.token === this.ts.SyntaxKind.ImplementsKeyword) {
-                            result.implemented.push(nn.getText());
-                        }
-                    });
-                }
-            });
-        });
-
-        Object.defineProperty(result, 'diagnostics', {
-            value: this.normalizeDiagnostics(this.ts.getPreEmitDiagnostics(languageService.getProgram())),
-            configurable: false,
-            writable: false,
-        });
-
-        Object.keys(result.files).forEach((key) => {
-            const file: ICompilerFile = result.files[key];
-            const output: EmitOutput = languageService.getEmitOutput(file.name);
-
-            file.name = key.replace(/\.ts$/g, '.js');
-
-            delete result.files[key];
-            result.files[file.name] = file;
-
-            file.compiled = output.outputFiles[0].text;
-        });
-
-        result.duration = Date.now() - startTime;
-
-        return result;
-    }
-
-    private normalizeDiagnostics(diagnostics: Array<Diagnostic>): Array<ICompilerDiagnostic> {
-        return diagnostics.map((diag) => {
-            const message = this.ts.flattenDiagnosticMessageText(diag.messageText, '\n');
-
-            const norm: ICompilerDiagnostic = {
-                originalDiagnostic: diag,
-                originalMessage: message,
-                message,
-            };
-
-            // Let's make the object more "loggable"
-            Object.defineProperties(norm, {
-                originalDiagnostic: { enumerable: false },
-            });
-
-            if (diag.file) {
-                const { line, character } = diag.file.getLineAndCharacterOfPosition(diag.start);
-                const lineStart = diag.file.getPositionOfLineAndCharacter(line, 0);
-
-                Object.assign(norm, {
-                    filename: diag.file.fileName,
-                    line,
-                    character,
-                    lineText: diag.file.getText().substring(lineStart, diag.file.getLineEndOfPosition(lineStart)),
-                    message: `Error ${ diag.file.fileName } (${ line + 1 },${ character + 1 }): ${ message }`,
-                });
-            }
-
-            return norm;
-        });
-    }
-
-    public resolvePath(containingFile: string, moduleName: string, cwd: string): string {
-        const currentFolderPath = path.dirname(containingFile).replace(cwd.replace(/\/$/, ''), '');
-        const modulePath = path.join(currentFolderPath, moduleName);
-
-        // Let's ensure we search for the App's modules first
-        const transformedModule = Utilities.transformModuleForCustomRequire(modulePath);
-        if (transformedModule) {
-            return transformedModule;
-        }
-    }
-
-    public resolver(
-        moduleName: string,
-        resolvedModules: Array<ResolvedModule>,
-        containingFile: string,
-        result: Omit<ICompilerResult, 'permissions'>,
-        cwd: string,
-        moduleResHost: ModuleResolutionHost,
-    ): number {
-        // Keep compatibility with apps importing apps-ts-definition
-        moduleName = moduleName.replace(/@rocket.chat\/apps-ts-definition\//, '@rocket.chat/apps-engine/definition/');
-
-        // ignore @types/node/*.d.ts
-        if (/node_modules\/@types\/node\/\S+\.d\.ts$/.test(containingFile)) {
-            return resolvedModules.push(undefined);
-        }
-
-        if (Utilities.allowedInternalModuleRequire(moduleName)) {
-            return resolvedModules.push({ resolvedFileName: `${ moduleName }.js` });
-        }
-
-        const resolvedPath = this.resolvePath(containingFile, moduleName, cwd);
-        if (result.files[resolvedPath]) {
-            return resolvedModules.push({ resolvedFileName: resolvedPath });
-        }
-
-        // Now, let's try the "standard" resolution but with our little twist on it
-        const rs = this.ts.resolveModuleName(moduleName, containingFile, this.compilerOptions, moduleResHost);
-        if (rs.resolvedModule) {
-            return resolvedModules.push(rs.resolvedModule);
-        }
-
-        return -1;
-    }
-
-    public getLibraryFile(fileName: string): ICompilerFile {
-        if (!fileName.endsWith('.d.ts')) {
-            return undefined;
-        }
-
-        const norm = path.normalize(fileName);
-
-        if (this.libraryFiles[norm]) {
-            return this.libraryFiles[norm];
-        }
-
-        if (!fs.existsSync(fileName)) {
-            return undefined;
-        }
-
-        this.libraryFiles[norm] = {
-            name: norm,
-            content: fs.readFileSync(fileName).toString(),
-            version: 0,
-        };
-
-        return this.libraryFiles[norm];
-    }
-
-    private checkInheritance(mainClassFile: string): void {
-        const { App: EngineBaseApp } = this.appRequire('@rocket.chat/apps-engine/definition/App');
-        const mainClassModule = this.requireCompiled(mainClassFile);
-
-        if (!mainClassModule.default && !mainClassModule[mainClassFile]) {
-            throw new Error(`There must be an exported class "${ mainClassFile }" or a default export in the main class file.`);
-        }
-
-        const RealApp = mainClassModule.default ? mainClassModule.default : mainClassModule[mainClassFile];
-        const mockInfo = { name: '', requiredApiVersion: '', author: { name: '' } };
-        const mockLogger = { debug: () => { } };
-        const realApp = new RealApp(mockInfo, mockLogger);
-
-        if (!(realApp instanceof EngineBaseApp)) {
-            throw new Error('App must extend apps-engine\'s "App" abstract class.'
-                + ' Maybe you forgot to install dependencies? Try running `npm install`'
-                + ' in your app folder to fix it.',
-            );
-        }
-    }
-
-    /**
-     * Require a module from the app compiled  source files
-     */
-    private requireCompiled(filename: string): any {
-        const exports = {};
-        const context = vm.createContext({
-            require: (filepath: string) => {
-                // Handles Apps-Engine import
-                if (filepath.startsWith('@rocket.chat/apps-engine/definition/')) {
-                    return require(`${ this.wd }/node_modules/${ filepath }`);
-                }
-
-                // Handles native node modules import
-                if (Utilities.allowedInternalModuleRequire(filepath)) {
-                    return require(filepath);
-                }
-
-                // At this point, if the app is trying to require anything that
-                // is not a relative path, we don't want to let it through
-                if (!filepath.startsWith('.')) {
-                    return undefined;
-                }
-
-                filepath = path.normalize(`${ path.dirname(filename) }/${ filepath }`);
-
-                // Handles import of other files in app's source
-                if (this.compiled[filepath.endsWith('.js') ? filepath : `${ filepath }.js`]) {
-                    return this.requireCompiled(filepath);
-                }
-            },
-            exports,
-        });
-        vm.runInContext(this.compiled[`${ filename }.js`], context);
-        return exports;
-    }
-
-    private isValidFile(file: ICompilerFile): boolean {
-        if (!file || !file.name || !file.content) {
-            return false;
-        }
-
-        return file.name.trim() !== ''
-            && path.normalize(file.name)
-            && file.content.trim() !== '';
     }
 }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -49,11 +49,11 @@ export async function compile(compilerDesc: ICompilerDescriptor, sourceDir: stri
     }
 
     try {
-        const compiler = new AppsCompiler(compilerDesc, appTs);
+        const compiler = new AppsCompiler(compilerDesc, sourceDir, appTs);
 
         log.debug('Starting compilation...');
 
-        const result = await compiler.compile(sourceDir);
+        const result = await compiler.compile();
 
         if (result.diagnostics.length) {
             return result;

--- a/src/compiler/AppsEngineValidator.ts
+++ b/src/compiler/AppsEngineValidator.ts
@@ -1,0 +1,100 @@
+import * as vm from 'vm';
+import path from 'path';
+
+import { ICompilerResult } from '../definition';
+import { IPermission } from '../definition/IPermission';
+import { getAvailablePermissions } from '../misc/getAvailablePermissions';
+import { Utilities } from '../misc/Utilities';
+
+export class AppsEngineValidator {
+    constructor(private readonly appSourceRequire: NodeRequire) { }
+
+    public validateAppPermissionsSchema(permissions: Array<IPermission>): void {
+        if (!permissions) {
+            return;
+        }
+
+        if (!Array.isArray(permissions)) {
+            throw new Error('Invalid permission definition. Check your manifest file.');
+        }
+
+        const permissionsRequire = this.appSourceRequire('@rocket.chat/apps-engine/server/permissions/AppPermissions');
+
+        if (!permissionsRequire || !permissionsRequire.AppPermissions) {
+            return;
+        }
+
+        const availablePermissions = getAvailablePermissions(permissionsRequire.AppPermissions);
+
+        permissions.forEach((permission) => {
+            if (permission && !availablePermissions.includes(permission.name)) {
+                throw new Error(`Invalid permission "${ String(permission.name) }" defined. Check your manifest file`);
+            }
+        });
+    }
+
+    public isValidAppInterface(interfaceName: string): boolean {
+        const { AppInterface } = this.appSourceRequire('@rocket.chat/apps-engine/definition/metadata');
+
+        return !!AppInterface[interfaceName];
+    }
+
+    public checkInheritance(mainClassFile: string, compilationResult: ICompilerResult): void {
+        const { App: EngineBaseApp } = this.appSourceRequire('@rocket.chat/apps-engine/definition/App');
+        const mainClassModule = this.compiledRequire(mainClassFile, compilationResult);
+
+        if (!mainClassModule.default && !mainClassModule[mainClassFile]) {
+            throw new Error(`There must be an exported class "${ mainClassFile }" or a default export in the main class file.`);
+        }
+
+        const RealApp = mainClassModule.default ? mainClassModule.default : mainClassModule[mainClassFile];
+        const mockInfo = { name: '', requiredApiVersion: '', author: { name: '' } };
+        const mockLogger = { debug: () => { } };
+        const realApp = new RealApp(mockInfo, mockLogger);
+
+        if (!(realApp instanceof EngineBaseApp)) {
+            throw new Error('App must extend apps-engine\'s "App" abstract class.'
+                + ' Maybe you forgot to install dependencies? Try running `npm install`'
+                + ' in your app folder to fix it.',
+            );
+        }
+    }
+
+    /**
+     * Require a module from the app compiled  source files
+     */
+    private compiledRequire(filename: string, compilationResult: ICompilerResult): any {
+        const exports = {};
+        const context = vm.createContext({
+            require: (filepath: string) => {
+                // Handles Apps-Engine import
+                if (filepath.startsWith('@rocket.chat/apps-engine/definition/')) {
+                    return this.appSourceRequire(filepath);
+                }
+
+                // Handles native node modules import
+                if (Utilities.allowedInternalModuleRequire(filepath)) {
+                    return require(filepath);
+                }
+
+                // At this point, if the app is trying to require anything that
+                // is not a relative path, we don't want to let it through
+                if (!filepath.startsWith('.')) {
+                    return undefined;
+                }
+
+                filepath = path.normalize(`${ path.dirname(filename) }/${ filepath }`);
+
+                // Handles import of other files in app's source
+                if (compilationResult.files[filepath.endsWith('.js') ? filepath : `${ filepath }.js`]) {
+                    return this.compiledRequire(filepath, compilationResult);
+                }
+            },
+            exports,
+        });
+
+        vm.runInContext(compilationResult.files[`${ filename }.js` as keyof ICompilerResult['files']].compiled, context);
+
+        return exports;
+    }
+}

--- a/src/compiler/TypescriptCompiler.ts
+++ b/src/compiler/TypescriptCompiler.ts
@@ -1,0 +1,285 @@
+import fs from 'fs';
+import path from 'path';
+import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
+import {
+    CompilerOptions,
+    EmitOutput,
+    LanguageService,
+    LanguageServiceHost,
+    ModuleResolutionHost,
+    ResolvedModule,
+} from 'typescript';
+
+import { TypeScript } from '../AppsCompiler';
+import { IAppSource, ICompilerDiagnostic, ICompilerFile, ICompilerResult, IMapCompilerFile } from '../definition';
+import { normalizeDiagnostics } from '../misc/normalizeDiagnostics';
+import { Utilities } from '../misc/Utilities';
+import { AppsEngineValidator } from './AppsEngineValidator';
+
+export class TypescriptCompiler {
+    private readonly compilerOptions: CompilerOptions;
+
+    private libraryFiles: IMapCompilerFile;
+
+    constructor(
+        private readonly sourcePath: string,
+        private readonly ts: TypeScript,
+        private readonly appValidator: AppsEngineValidator,
+    ) {
+        this.compilerOptions = {
+            target: this.ts.ScriptTarget.ES2017,
+            module: this.ts.ModuleKind.CommonJS,
+            moduleResolution: this.ts.ModuleResolutionKind.NodeJs,
+            declaration: false,
+            noImplicitAny: false,
+            removeComments: true,
+            strictNullChecks: true,
+            noImplicitReturns: true,
+            emitDecoratorMetadata: true,
+            experimentalDecorators: true,
+            types: ['node'],
+            // Set this to true if you would like to see the module resolution process
+            traceResolution: false,
+        };
+
+        this.libraryFiles = {};
+    }
+
+    public transpileSource({ appInfo, sourceFiles: files }: IAppSource): ICompilerResult {
+        if (!appInfo.classFile || !files[appInfo.classFile] || !this.isValidFile(files[appInfo.classFile])) {
+            throw new Error(`Invalid App package. Could not find the classFile (${ appInfo.classFile }) file.`);
+        }
+
+        const startTime = Date.now();
+
+        this.appValidator.validateAppPermissionsSchema(appInfo.permissions);
+
+        const result: ICompilerResult = {
+            files,
+            implemented: [],
+            diagnostics: [],
+            duration: NaN,
+            name: appInfo.name,
+            version: appInfo.version,
+            typeScriptVersion: this.ts.version,
+            permissions: appInfo.permissions,
+        };
+
+        // Verify all file names are normalized
+        // and that the files are valid
+        Object.keys(result.files).forEach((key) => {
+            if (!this.isValidFile(result.files[key])) {
+                throw new Error(`Invalid TypeScript file: "${ key }".`);
+            }
+
+            result.files[key].name = path.normalize(result.files[key].name);
+        });
+
+        const modulesNotFound: ICompilerDiagnostic[] = [];
+        const host = {
+            getScriptFileNames: () => Object.keys(result.files),
+            getScriptVersion: (fileName) => {
+                fileName = path.normalize(fileName);
+                const file = result.files[fileName] || this.getLibraryFile(fileName);
+                return file && file.version.toString();
+            },
+            getScriptSnapshot: (fileName) => {
+                fileName = path.normalize(fileName);
+                const file = result.files[fileName] || this.getLibraryFile(fileName);
+
+                if (!file || !file.content) {
+                    return;
+                }
+
+                return this.ts.ScriptSnapshot.fromString(file.content);
+            },
+            getCompilationSettings: () => this.compilerOptions,
+            getCurrentDirectory: () => this.sourcePath,
+            getDefaultLibFileName: () => this.ts.getDefaultLibFilePath(this.compilerOptions),
+            fileExists: (fileName: string): boolean => this.ts.sys.fileExists(fileName),
+            readFile: (fileName: string): string | undefined => this.ts.sys.readFile(fileName),
+            resolveModuleNames: (moduleNames: Array<string>, containingFile: string): Array<ResolvedModule> => {
+                const resolvedModules: ResolvedModule[] = [];
+                const moduleResHost: ModuleResolutionHost = {
+                    fileExists: host.fileExists, readFile: host.readFile, trace: (traceDetail) => console.log(traceDetail),
+                };
+
+                for (const moduleName of moduleNames) {
+                    const index = this.resolver(moduleName, resolvedModules, containingFile, result, moduleResHost);
+
+                    if (index === -1) {
+                        modulesNotFound.push({
+                            filename: containingFile,
+                            line: 0,
+                            character: 0,
+                            lineText: '',
+                            message: `Failed to resolve module: ${ moduleName }`,
+                            originalMessage: `Module not found: ${ moduleName }`,
+                            originalDiagnostic: undefined,
+                        });
+                    }
+                }
+
+                return resolvedModules;
+            },
+        } as LanguageServiceHost;
+
+        const languageService = this.ts.createLanguageService(host, this.ts.createDocumentRegistry());
+
+        try {
+            const coDiag = languageService.getCompilerOptionsDiagnostics();
+
+            if (coDiag.length !== 0) {
+                console.log(coDiag);
+
+                console.error('A VERY UNEXPECTED ERROR HAPPENED THAT SHOULD NOT!');
+                // console.error('Please report this error with a screenshot of the logs. ' +
+                //     `Also, please email a copy of the App being installed/updated: ${ info.name } v${ info.version } (${ info.id })`);
+
+                throw new Error(`Language Service's Compiler Options Diagnostics contains ${ coDiag.length } diagnostics.`);
+            }
+        } catch (e) {
+            if (modulesNotFound.length !== 0) {
+                result.diagnostics = modulesNotFound;
+                result.duration = Date.now() - startTime;
+
+                return result;
+            }
+
+            throw e;
+        }
+
+        result.implemented = this.getImplementedInterfaces(languageService, appInfo);
+
+        Object.defineProperty(result, 'diagnostics', {
+            value: normalizeDiagnostics(this.ts.getPreEmitDiagnostics(languageService.getProgram())),
+            configurable: false,
+            writable: false,
+        });
+
+        Object.keys(result.files).forEach((key) => {
+            const file: ICompilerFile = result.files[key];
+            const output: EmitOutput = languageService.getEmitOutput(file.name);
+
+            file.name = key.replace(/\.ts$/g, '.js');
+
+            delete result.files[key];
+            result.files[file.name] = file;
+
+            file.compiled = output.outputFiles[0].text;
+        });
+
+        this.appValidator.checkInheritance(appInfo.classFile.replace(/\.ts$/, ''), result);
+
+        result.duration = Date.now() - startTime;
+
+        return result;
+    }
+
+    private resolver(
+        moduleName: string,
+        resolvedModules: Array<ResolvedModule>,
+        containingFile: string,
+        result: ICompilerResult,
+        moduleResHost: ModuleResolutionHost,
+    ): number {
+        // Keep compatibility with apps importing apps-ts-definition
+        moduleName = moduleName.replace(/@rocket.chat\/apps-ts-definition\//, '@rocket.chat/apps-engine/definition/');
+
+        // ignore @types/node/*.d.ts
+        if (/node_modules\/@types\/node\/\S+\.d\.ts$/.test(containingFile)) {
+            return resolvedModules.push(undefined);
+        }
+
+        if (Utilities.allowedInternalModuleRequire(moduleName)) {
+            return resolvedModules.push({ resolvedFileName: `${ moduleName }.js` });
+        }
+
+        const resolvedPath = this.resolvePath(containingFile, moduleName);
+        if (result.files[resolvedPath]) {
+            return resolvedModules.push({ resolvedFileName: resolvedPath });
+        }
+
+        // Now, let's try the "standard" resolution but with our little twist on it
+        const rs = this.ts.resolveModuleName(moduleName, containingFile, this.compilerOptions, moduleResHost);
+        if (rs.resolvedModule) {
+            return resolvedModules.push(rs.resolvedModule);
+        }
+
+        return -1;
+    }
+
+    private resolvePath(containingFile: string, moduleName: string): string {
+        const currentFolderPath = path.dirname(containingFile).replace(this.sourcePath.replace(/\/$/, ''), '');
+        const modulePath = path.join(currentFolderPath, moduleName);
+
+        // Let's ensure we search for the App's modules first
+        const transformedModule = Utilities.transformModuleForCustomRequire(modulePath);
+        if (transformedModule) {
+            return transformedModule;
+        }
+    }
+
+    private getImplementedInterfaces(languageService: LanguageService, appInfo: IAppInfo): ICompilerResult['implemented'] {
+        const result: ICompilerResult['implemented'] = [];
+
+        const src = languageService.getProgram().getSourceFile(appInfo.classFile);
+
+        this.ts.forEachChild(src, (n) => {
+            if (!this.ts.isClassDeclaration(n)) {
+                return;
+            }
+
+            this.ts.forEachChild(n, (node) => {
+                if (!this.ts.isHeritageClause(node)) {
+                    return;
+                }
+
+                this.ts.forEachChild(node, (nn) => {
+                    const interfaceName = nn.getText();
+                    if (node.token === this.ts.SyntaxKind.ImplementsKeyword
+                        && this.appValidator.isValidAppInterface(interfaceName)
+                    ) {
+                        result.push(interfaceName);
+                    }
+                });
+            });
+        });
+
+        return result;
+    }
+
+    private getLibraryFile(fileName: string): ICompilerFile {
+        if (!fileName.endsWith('.d.ts')) {
+            return undefined;
+        }
+
+        const norm = path.normalize(fileName);
+
+        if (this.libraryFiles[norm]) {
+            return this.libraryFiles[norm];
+        }
+
+        if (!fs.existsSync(fileName)) {
+            return undefined;
+        }
+
+        this.libraryFiles[norm] = {
+            name: norm,
+            content: fs.readFileSync(fileName).toString(),
+            version: 0,
+        };
+
+        return this.libraryFiles[norm];
+    }
+
+    private isValidFile(file: ICompilerFile): boolean {
+        if (!file || !file.name || !file.content) {
+            return false;
+        }
+
+        return file.name.trim() !== ''
+            && path.normalize(file.name)
+            && file.content.trim() !== '';
+    }
+}

--- a/src/definition/ICompilerResult.ts
+++ b/src/definition/ICompilerResult.ts
@@ -10,5 +10,5 @@ export interface ICompilerResult {
     name: string;
     version: string;
     typeScriptVersion: string;
-    permissions: Array<IPermission>;
+    permissions?: Array<IPermission>;
 }

--- a/src/misc/normalizeDiagnostics.ts
+++ b/src/misc/normalizeDiagnostics.ts
@@ -1,0 +1,34 @@
+import { Diagnostic, flattenDiagnosticMessageText } from 'typescript';
+import { ICompilerDiagnostic } from '../definition';
+
+export function normalizeDiagnostics(diagnostics: Array<Diagnostic>): Array<ICompilerDiagnostic> {
+    return diagnostics.map((diag) => {
+        const message = flattenDiagnosticMessageText(diag.messageText, '\n');
+
+        const norm: ICompilerDiagnostic = {
+            originalDiagnostic: diag,
+            originalMessage: message,
+            message,
+        };
+
+        // Let's make the object more "loggable"
+        Object.defineProperties(norm, {
+            originalDiagnostic: { enumerable: false },
+        });
+
+        if (diag.file) {
+            const { line, character } = diag.file.getLineAndCharacterOfPosition(diag.start);
+            const lineStart = diag.file.getPositionOfLineAndCharacter(line, 0);
+
+            Object.assign(norm, {
+                filename: diag.file.fileName,
+                line,
+                character,
+                lineText: diag.file.getText().substring(lineStart, diag.file.getLineEndOfPosition(lineStart)),
+                message: `Error ${ diag.file.fileName } (${ line + 1 },${ character + 1 }): ${ message }`,
+            });
+        }
+
+        return norm;
+    });
+}

--- a/src/misc/util.ts
+++ b/src/misc/util.ts
@@ -1,2 +1,0 @@
-// The fallback typescript v2.9.2 is too old, we need it for polyfill
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;

--- a/tests/AppsCompiler.spec.ts
+++ b/tests/AppsCompiler.spec.ts
@@ -1,13 +1,14 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+import * as ts from 'typescript';
 
 import { AppsCompiler } from '../src/AppsCompiler';
 
 describe('AppsCompiler', () => {
     it('shouldn\'t throw an error', () => {
         expect(() => new AppsCompiler({
-           tool: 'tester',
-           version: '0',
-        })).not.throw();
+            tool: 'tester',
+            version: '0',
+        }, process.cwd(), ts)).not.throw();
     });
 });


### PR DESCRIPTION
Adding Rollup allows us to bundle the potential NPM dependencies of apps into the app package, making it possible to use those in the Apps-Engine