### PR TITLE
[IMPROVE] Add compilation warnings and clearing native modules for compilation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -179,9 +179,9 @@
       }
     },
     "@rocket.chat/apps-engine": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@rocket.chat/apps-engine/-/apps-engine-1.22.2.tgz",
-      "integrity": "sha512-wmFy/YOF5nZRxgMvTPE4zAAGidIrePndEPFuslZc+ocsZeO3zDl6i8MT0WN0vVLM6htEOe4/O4XS2H28XCAwnw==",
+      "version": "1.28.0-alpha.5428",
+      "resolved": "https://registry.npmjs.org/@rocket.chat/apps-engine/-/apps-engine-1.28.0-alpha.5428.tgz",
+      "integrity": "sha512-M2i74yj3fvOw60FssXrF+dSQ5F9U/LOa865UhJH8ijcY1lTbqku1v7gXEi4GaTZ9HSS7bV47YECCj5qQ1ENgcw==",
       "requires": {
         "adm-zip": "^0.4.9",
         "cryptiles": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "ts-node": "^9.1.1"
     },
     "dependencies": {
-        "@rocket.chat/apps-engine": "^1.22.2",
+        "@rocket.chat/apps-engine": "^1.28.0-alpha.5428",
         "esbuild": "^0.12.16",
         "figures": "^3.0.0",
         "fs-extra": "^8.1.0",

--- a/src/bundler/esbuild.ts
+++ b/src/bundler/esbuild.ts
@@ -18,6 +18,9 @@ export async function bundleCompilation(r: ICompilerResult, validator: AppsEngin
         minify: true,
         platform: 'node',
         target: ['node10'],
+        define: {
+            'global.Promise': 'Promise'
+        },
         external: [
             '@rocket.chat/apps-engine/*',
         ],

--- a/src/bundler/esbuild.ts
+++ b/src/bundler/esbuild.ts
@@ -19,7 +19,7 @@ export async function bundleCompilation(r: ICompilerResult, validator: AppsEngin
         platform: 'node',
         target: ['node10'],
         define: {
-            'global.Promise': 'Promise'
+            'global.Promise': 'Promise',
         },
         external: [
             '@rocket.chat/apps-engine/*',

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -6,16 +6,12 @@ import path from 'path';
 
 import * as TS from 'typescript';
 
+import log from './misc/logger';
+
 import { AppsCompiler } from '.';
 import { CompilerFileNotFoundError, ICompilerDescriptor, ICompilerResult } from './definition';
 
 const { promises: fs, constants: { R_OK: READ_ACCESS } } = require('fs');
-
-const log = require('simple-node-logger').createSimpleLogger({
-    timestampFormat: 'YYYY-MM-DD HH:mm:ss.SSS',
-});
-
-log.setLevel(process.env.LOG_LEVEL || 'info');
 
 export async function compile(compilerDesc: ICompilerDescriptor, sourceDir: string, outputFile: string): Promise<ICompilerResult> {
     sourceDir = path.resolve(sourceDir);

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 import * as TS from 'typescript';
 
-import log from './misc/logger';
+import logger from './misc/logger';
 
 import { AppsCompiler } from '.';
 import { CompilerFileNotFoundError, ICompilerDescriptor, ICompilerResult } from './definition';
@@ -17,37 +17,37 @@ export async function compile(compilerDesc: ICompilerDescriptor, sourceDir: stri
     sourceDir = path.resolve(sourceDir);
     outputFile = path.resolve(outputFile);
 
-    log.info('Compiling app at ', sourceDir);
+    logger.info('Compiling app at ', sourceDir);
 
     const sourceAppManifest = path.format({ dir: sourceDir, base: 'app.json' });
 
     try {
-        log.debug('Checking access to app\'s source folder');
+        logger.debug('Checking access to app\'s source folder');
 
         await fs.access(sourceAppManifest, READ_ACCESS);
     } catch (error) {
-        log.error(`Can't read app's manifest in "${ sourceAppManifest }". Are you sure there is an app there?`);
+        logger.error(`Can't read app's manifest in "${ sourceAppManifest }". Are you sure there is an app there?`);
         throw new CompilerFileNotFoundError(sourceAppManifest);
     }
 
     const appRequire = createRequire(sourceAppManifest);
 
-    log.debug('Created require function for the app\'s folder scope');
+    logger.debug('Created require function for the app\'s folder scope');
 
     let appTs: typeof TS | undefined;
 
     try {
         appTs = appRequire('typescript') as typeof TS;
 
-        log.debug(`Using TypeScript ${ appTs.version } as specified in app's dependencies`);
+        logger.debug(`Using TypeScript ${ appTs.version } as specified in app's dependencies`);
     } catch {
-        log.debug("App doesn't have the typescript package as a dependency - compiler will fall back to TypeScript 2.9.2");
+        logger.debug("App doesn't have the typescript package as a dependency - compiler will fall back to TypeScript 2.9.2");
     }
 
     try {
         const compiler = new AppsCompiler(compilerDesc, sourceDir, appTs);
 
-        log.debug('Starting compilation...');
+        logger.debug('Starting compilation...');
 
         const result = await compiler.compile();
 
@@ -55,21 +55,21 @@ export async function compile(compilerDesc: ICompilerDescriptor, sourceDir: stri
             return result;
         }
 
-        log.debug('Compilation complete, inspection \n', inspect(result));
-        log.debug('Starting bundling...');
+        logger.debug('Compilation complete, inspection \n', inspect(result));
+        logger.debug('Starting bundling...');
 
         await compiler.bundle();
 
-        log.debug('Compilation complete, inspection \n', inspect(compiler.getLatestCompilationResult()));
-        log.debug('Starting packaging...');
+        logger.debug('Compilation complete, inspection \n', inspect(compiler.getLatestCompilationResult()));
+        logger.debug('Starting packaging...');
 
         await compiler.outputZip(outputFile);
 
-        log.info(`Compilation successful! Took ${ result.duration / 1000 }s. Package saved at `, outputFile);
+        logger.info(`Compilation successful! Took ${ result.duration / 1000 }s. Package saved at `, outputFile);
 
         return compiler.getLatestCompilationResult();
     } catch (error) {
-        log.error('Compilation was unsuccessful');
+        logger.error('Compilation was unsuccessful');
 
         throw error;
     }

--- a/src/compiler/TypescriptCompiler.ts
+++ b/src/compiler/TypescriptCompiler.ts
@@ -1,5 +1,7 @@
+import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
+
 import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
 import {
     CompilerOptions,
@@ -16,7 +18,6 @@ import { normalizeDiagnostics } from '../misc/normalizeDiagnostics';
 import { Utilities } from '../misc/Utilities';
 import { AppsEngineValidator } from './AppsEngineValidator';
 import logger from '../misc/logger';
-import { EventEmitter } from 'events';
 
 export class TypescriptCompiler {
     private readonly compilerOptions: CompilerOptions;
@@ -86,13 +87,13 @@ export class TypescriptCompiler {
                 case 'external':
                     if (!hasExternalDependencies) {
                         hasExternalDependencies = true;
-                        logger.warn(`App has external module(s) as dependency`);
+                        logger.warn('App has external module(s) as dependency');
                     }
                     break;
                 case 'native':
                     if (!hasNativeDependencies) {
                         hasNativeDependencies = true;
-                        logger.warn(`App has native module(s) as dependency`);
+                        logger.warn('App has native module(s) as dependency');
                     }
                     break;
                 default:
@@ -209,7 +210,7 @@ export class TypescriptCompiler {
         containingFile: string,
         result: ICompilerResult,
         moduleResHost: ModuleResolutionHost,
-        dependencyCheck: EventEmitter
+        dependencyCheck: EventEmitter,
     ): number {
         // Keep compatibility with apps importing apps-ts-definition
         moduleName = moduleName.replace(/@rocket.chat\/apps-ts-definition\//, '@rocket.chat/apps-engine/definition/');
@@ -232,7 +233,7 @@ export class TypescriptCompiler {
         // Now, let's try the "standard" resolution but with our little twist on it
         const rs = this.ts.resolveModuleName(moduleName, containingFile, this.compilerOptions, moduleResHost);
         if (rs.resolvedModule) {
-            if (rs.resolvedModule.isExternalLibraryImport && rs.resolvedModule.packageId && rs.resolvedModule.packageId.name != '@rocket.chat/apps-engine') {
+            if (rs.resolvedModule.isExternalLibraryImport && rs.resolvedModule.packageId && rs.resolvedModule.packageId.name !== '@rocket.chat/apps-engine') {
                 dependencyCheck.emit('dependencyCheck', 'external');
             }
 

--- a/src/compiler/TypescriptCompiler.ts
+++ b/src/compiler/TypescriptCompiler.ts
@@ -15,6 +15,8 @@ import { IAppSource, ICompilerDiagnostic, ICompilerFile, ICompilerResult, IMapCo
 import { normalizeDiagnostics } from '../misc/normalizeDiagnostics';
 import { Utilities } from '../misc/Utilities';
 import { AppsEngineValidator } from './AppsEngineValidator';
+import logger from '../misc/logger';
+import { EventEmitter } from 'events';
 
 export class TypescriptCompiler {
     private readonly compilerOptions: CompilerOptions;
@@ -75,6 +77,29 @@ export class TypescriptCompiler {
             result.files[key].name = path.normalize(result.files[key].name);
         });
 
+        let hasExternalDependencies = false;
+        let hasNativeDependencies = false;
+        const dependencyCheck = new EventEmitter();
+
+        dependencyCheck.on('dependencyCheck', (dependencyType) => {
+            switch (dependencyType) {
+                case 'external':
+                    if (!hasExternalDependencies) {
+                        hasExternalDependencies = true;
+                        logger.warn(`App has external module(s) as dependency`);
+                    }
+                    break;
+                case 'native':
+                    if (!hasNativeDependencies) {
+                        hasNativeDependencies = true;
+                        logger.warn(`App has native module(s) as dependency`);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        });
+
         const modulesNotFound: ICompilerDiagnostic[] = [];
         const host = {
             getScriptFileNames: () => Object.keys(result.files),
@@ -105,7 +130,7 @@ export class TypescriptCompiler {
                 };
 
                 for (const moduleName of moduleNames) {
-                    const index = this.resolver(moduleName, resolvedModules, containingFile, result, moduleResHost);
+                    const index = this.resolver(moduleName, resolvedModules, containingFile, result, moduleResHost, dependencyCheck);
 
                     if (index === -1) {
                         modulesNotFound.push({
@@ -184,6 +209,7 @@ export class TypescriptCompiler {
         containingFile: string,
         result: ICompilerResult,
         moduleResHost: ModuleResolutionHost,
+        dependencyCheck: EventEmitter
     ): number {
         // Keep compatibility with apps importing apps-ts-definition
         moduleName = moduleName.replace(/@rocket.chat\/apps-ts-definition\//, '@rocket.chat/apps-engine/definition/');
@@ -194,6 +220,7 @@ export class TypescriptCompiler {
         }
 
         if (Utilities.allowedInternalModuleRequire(moduleName)) {
+            dependencyCheck.emit('dependencyCheck', 'native');
             return resolvedModules.push({ resolvedFileName: `${ moduleName }.js` });
         }
 
@@ -205,6 +232,10 @@ export class TypescriptCompiler {
         // Now, let's try the "standard" resolution but with our little twist on it
         const rs = this.ts.resolveModuleName(moduleName, containingFile, this.compilerOptions, moduleResHost);
         if (rs.resolvedModule) {
+            if (rs.resolvedModule.isExternalLibraryImport && rs.resolvedModule.packageId && rs.resolvedModule.packageId.name != '@rocket.chat/apps-engine') {
+                dependencyCheck.emit('dependencyCheck', 'external');
+            }
+
             return resolvedModules.push(rs.resolvedModule);
         }
 

--- a/src/misc/Utilities.ts
+++ b/src/misc/Utilities.ts
@@ -13,6 +13,7 @@ enum AllowedInternalModules {
     http,
     https,
     zlib,
+    util,
     os
 }
 

--- a/src/misc/Utilities.ts
+++ b/src/misc/Utilities.ts
@@ -10,6 +10,10 @@ enum AllowedInternalModules {
     events,
     stream,
     net,
+    http,
+    https,
+    zlib,
+    os
 }
 
 export class Utilities {

--- a/src/misc/logger.ts
+++ b/src/misc/logger.ts
@@ -1,0 +1,7 @@
+const logger = require('simple-node-logger').createSimpleLogger({
+    timestampFormat: 'YYYY-MM-DD HH:mm:ss.SSS',
+});
+
+logger.setLevel(process.env.LOG_LEVEL || 'info');
+
+export default logger;

--- a/src/misc/logger.ts
+++ b/src/misc/logger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const logger = require('simple-node-logger').createSimpleLogger({
     timestampFormat: 'YYYY-MM-DD HH:mm:ss.SSS',
 });

--- a/src/packager/AppPackager.ts
+++ b/src/packager/AppPackager.ts
@@ -7,6 +7,7 @@ import glob, { IOptions } from 'glob';
 import { FolderDetails } from '../misc/folderDetails';
 import { IBundledCompilerResult, ICompilerDescriptor, ICompilerResult } from '../definition';
 import { isBundled } from '../bundler';
+import logger from '../misc/logger';
 
 export class AppPackager {
     public static GlobOptions: IOptions = {
@@ -75,6 +76,10 @@ export class AppPackager {
             throw new Error('No files to package were found');
         }
 
+        if (!this.isFilePresent(matches, 'package-lock.json')) {
+            logger.warn('No package-lock.json found');
+        }
+
         await Promise.all(
             matches.map(async (realPath) => {
                 const zipPath = path.relative(this.fd.folder, realPath);
@@ -125,5 +130,10 @@ export class AppPackager {
                 .on('close', resolve)
                 .on('error', reject);
         });
+    }
+
+    private isFilePresent(fileList: Array<string>, fileName: string): boolean {
+        const targetFilePath = path.join(this.fd.folder, fileName);
+        return fileList.includes(targetFilePath);
     }
 }


### PR DESCRIPTION
Improvements to the developer experience were needed as we are allowing npm dependencies and some native modules in our apps. 

Also the logger was moved to its own file so it can be required by other modules.