### PR TITLE
[FIX] Require logic is faulty for compiled apps

### DIFF
--- a/src/compiler/AppsEngineValidator.ts
+++ b/src/compiler/AppsEngineValidator.ts
@@ -113,7 +113,7 @@ export class AppsEngineValidator {
         const result = vm.runInContext(compilationResult.files[`${ filename }.js` as keyof ICompilerResult['files']].compiled, context);
 
         /**
-          * `result` will contain the ONLY the result of the last line evaluated
+          * `result` will contain ONLY the result of the last line evaluated
           * in the script by `vm.runInContext`, and NOT the full `exports` object.
           *
           * However, we need to handle this case due to backwards compatibility,

--- a/src/compiler/AppsEngineValidator.ts
+++ b/src/compiler/AppsEngineValidator.ts
@@ -112,6 +112,21 @@ export class AppsEngineValidator {
 
         const result = vm.runInContext(compilationResult.files[`${ filename }.js` as keyof ICompilerResult['files']].compiled, context);
 
-        return result || exports;
+        /**
+          * `result` will contain the ONLY the result of the last line evaluated
+          * in the script by `vm.runInContext`, and NOT the full `exports` object.
+          *
+          * However, we need to handle this case due to backwards compatibility,
+          * since the main class file might export a class with an unknown name,
+          * which was supported in the early versions of the Apps-Engine.
+          *
+          * So here, if we find that the required file exports ONLY ONE property,
+          * which is what happens in the case of the main class file, we can return
+          * the `result`; otherwise, we return the full `exports` object.
+          */
+        if (Object.keys(exports).length === 1) {
+            return result;
+        }
+        return exports;
     }
 }


### PR DESCRIPTION
The logic used to `require` modules after the app is compiled was wrong, considering only the result from evaluating _the last line from the required script_.

We needed to handle this case due to backward compatibility since the main class file might export a class with an unknown name, which was supported in the early versions of the Apps-Engine.

This PR fixes the problem by returning the previous result ONLY IF we find that the required file exports ONLY ONE property, which is what happens in the case of the main class file; otherwise, we return the full `exports` object.