### PR TITLE
feat: Add compiler option to read project's tsconfig file

### DIFF
--- a/src/AppsCompiler.ts
+++ b/src/AppsCompiler.ts
@@ -16,8 +16,8 @@ export type TypeScript = typeof fallbackTypescript;
 
 export type AppCompilerOptions = {
     /**
-    /* Indicates whether the AppCompiler should take into
-    /* account the .tsconfig file when compiling the app
+     * Indicates whether the AppCompiler should take into
+     * account the .tsconfig file when compiling the app
      */
     readTsProjectFile?: boolean;
 };

--- a/src/AppsCompiler.ts
+++ b/src/AppsCompiler.ts
@@ -10,8 +10,22 @@ import { AppPackager } from './packager';
 import { TypescriptCompiler } from './compiler/TypescriptCompiler';
 import { AppsEngineValidator } from './compiler/AppsEngineValidator';
 import getBundler, { AvailableBundlers, BundlerFunction } from './bundler';
+import logger from './misc/logger';
 
 export type TypeScript = typeof fallbackTypescript;
+
+export type AppCompilerOptions = {
+    /**
+    /* Indicates whether the AppCompiler should take into
+    /* account the .tsconfig file when compiling the app
+     */
+    readTsProjectFile?: boolean;
+};
+
+const defaultOptions: AppCompilerOptions = {
+    // Default to false for compatibility
+    readTsProjectFile: false,
+};
 
 export class AppsCompiler {
     private compilationResult?: ICompilerResult;
@@ -26,6 +40,7 @@ export class AppsCompiler {
         private readonly compilerDesc: ICompilerDescriptor,
         private readonly sourcePath: string,
         ts: TypeScript = fallbackTypescript,
+        private readonly options = defaultOptions,
     ) {
         this.validator = new AppsEngineValidator(createRequire(path.join(sourcePath, 'app.json')));
 
@@ -45,7 +60,11 @@ export class AppsCompiler {
     }
 
     public async compile(): Promise<ICompilerResult> {
-        const source = await getAppSource(this.sourcePath);
+        const source = await getAppSource(this.sourcePath, this.options);
+
+        if (source.compilerOptions) {
+            this.typescriptCompiler.setCompilerOptions(source.compilerOptions);
+        }
 
         this.compilationResult = this.typescriptCompiler.transpileSource(source);
 
@@ -65,7 +84,7 @@ export class AppsCompiler {
             // @NOTE this is important for generating the zip file with the correct name
             await fd.readInfoFile();
         } catch (e) {
-            console.error(e && e.message ? e.message : e);
+            logger.error(e && e.message ? e.message : e);
             return;
         }
 

--- a/src/compiler/TypescriptCompiler.ts
+++ b/src/compiler/TypescriptCompiler.ts
@@ -20,6 +20,8 @@ import { AppsEngineValidator } from './AppsEngineValidator';
 import logger from '../misc/logger';
 
 export class TypescriptCompiler {
+    private readonly nonConfigurableCompilerOptions: CompilerOptions;
+
     private readonly compilerOptions: CompilerOptions;
 
     private libraryFiles: IMapCompilerFile;
@@ -29,10 +31,16 @@ export class TypescriptCompiler {
         private readonly ts: TypeScript,
         private readonly appValidator: AppsEngineValidator,
     ) {
-        this.compilerOptions = {
+        // Things we shouldn't allow the app dev changing
+        this.nonConfigurableCompilerOptions = {
             target: this.ts.ScriptTarget.ES2017,
             module: this.ts.ModuleKind.CommonJS,
             moduleResolution: this.ts.ModuleResolutionKind.NodeJs,
+        };
+
+        this.compilerOptions = {
+            ...this.nonConfigurableCompilerOptions,
+            skipLibCheck: true,
             declaration: false,
             noImplicitAny: false,
             removeComments: true,
@@ -46,6 +54,10 @@ export class TypescriptCompiler {
         };
 
         this.libraryFiles = {};
+    }
+
+    public setCompilerOptions(options: CompilerOptions): void {
+        Object.assign(this.compilerOptions, options, this.nonConfigurableCompilerOptions);
     }
 
     public transpileSource({ appInfo, sourceFiles: files }: IAppSource): ICompilerResult {

--- a/src/definition/IAppSource.ts
+++ b/src/definition/IAppSource.ts
@@ -1,3 +1,4 @@
+import { CompilerOptions } from 'typescript';
 import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
 
 import { ICompilerFile } from './ICompilerFile';
@@ -5,4 +6,5 @@ import { ICompilerFile } from './ICompilerFile';
 export interface IAppSource {
     appInfo: IAppInfo;
     sourceFiles: { [filename: string]: ICompilerFile };
+    compilerOptions?: CompilerOptions;
 }


### PR DESCRIPTION
Adding a new option for the AppsCompiler to read and use `compilerOptions` from the `tsconfig.json` file inside the app's root folder.

The default behavior is to _not use the file_ - it is opt-in. This is because, since the compiler never used the settings from that file, some config might cause compilation errors that never occured before.

The CLI will handle the addition of this option

ARCH-1143