### PR TITLE
fix: adjust index import from apps compiling

### DIFF
--- a/src/compiler/TypescriptCompiler.ts
+++ b/src/compiler/TypescriptCompiler.ts
@@ -225,6 +225,16 @@ export class TypescriptCompiler {
             return resolvedModules.push({ resolvedFileName: `${ moduleName }.js` });
         }
 
+        const resolvedWithIndex = this.resolvePath(
+            containingFile,
+            `${ moduleName }/index`,
+        );
+        if (result.files[resolvedWithIndex]) {
+            return resolvedModules.push({
+                resolvedFileName: resolvedWithIndex,
+            });
+        }
+
         const resolvedPath = this.resolvePath(containingFile, moduleName);
         if (result.files[resolvedPath]) {
             return resolvedModules.push({ resolvedFileName: resolvedPath });


### PR DESCRIPTION
This pull request enhances the resolvePath method within the TypescriptCompiler class. The method resolvePath is responsible for resolving file paths based on the containing file and module name. The improvement ensures that when a file is successfully resolved, it is directly pushed into the resolvedModules array with the appropriate structure.

Previously, the method only checked if the resolved path exists in the` result.files `object. With this enhancement, if the resolved path exists, the corresponding object with the resolved filename is directly added to the resolvedModules array, simplifying the logic and improving readability.