### PR TITLE
Fix compiler package inclusion of ignored files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,39 @@ This library provides the core Rocket.Chat App compilation feature for any other
 
 This library exports an `AppsCompiler` class that handles compilation from file system path, and outputs a zip to the file system.
 
+## Configuration
+
+### .rcappsconfig File
+
+You can create a `.rcappsconfig` file in your project root to configure which files should be ignored during compilation and packaging. This file should contain a JSON object with an `ignore` array.
+
+Example `.rcappsconfig`:
+
+```json
+{
+    "ignore": [
+        "*.log",
+        "*.tmp",
+        "debug/**",
+        "temp-*",
+        ".env",
+        ".env.*",
+        "coverage/**",
+        "test/**",
+        "docs/**",
+        ".vscode/**"
+    ]
+}
+```
+
+The ignore patterns support:
+- Exact file names: `debug.log`
+- Glob patterns: `*.log`, `temp-*`
+- Directory patterns: `debug/**`, `node_modules`
+- File extensions: `*.tmp`
+
+Files matching these patterns will be excluded from both source compilation and the final package.
+
 ## Publishing to NPM
 
 This package is published to NPM using the `@rocket.chat` scope. To publish a new version, you need to have access to the `@rocket.chat` scope on NPM. If you don't have access, ask someone who does to add you to the scope.

--- a/example/.rcappsconfig
+++ b/example/.rcappsconfig
@@ -1,0 +1,18 @@
+{
+    "ignore": [
+        "*.log",
+        "*.tmp",
+        "debug/**",
+        "temp-*",
+        ".env",
+        ".env.*",
+        "coverage/**",
+        "*.spec.ts",
+        "*.test.ts",
+        "test/**",
+        "docs/**",
+        "*.md",
+        ".vscode/**",
+        ".idea/**"
+    ]
+}

--- a/src/compiler/getAppSource.ts
+++ b/src/compiler/getAppSource.ts
@@ -7,9 +7,17 @@ import type {
     ICompilerFile,
     IMapCompilerFile,
 } from "../definition";
-import { readRcappsConfig, shouldIgnoreFile, type IRcappsConfig } from "../misc/rcappsConfigReader";
+import {
+    readRcappsConfig,
+    shouldIgnoreFile,
+    type IRcappsConfig,
+} from "../misc/rcappsConfigReader";
 
-async function walkDirectory(directory: string, projectPath: string, rcappsConfig: IRcappsConfig | null): Promise<ICompilerFile[]> {
+async function walkDirectory(
+    directory: string,
+    projectPath: string,
+    rcappsConfig: IRcappsConfig | null,
+): Promise<ICompilerFile[]> {
     const dirents = await fs.readdir(directory, { withFileTypes: true });
     const files = await Promise.all(
         dirents
@@ -24,7 +32,7 @@ async function walkDirectory(directory: string, projectPath: string, rcappsConfi
                 }
 
                 // Check if this path should be ignored based on .rcappsconfig
-                if (rcappsConfig && rcappsConfig.ignore) {
+                if (rcappsConfig?.ignore) {
                     if (shouldIgnoreFile(relativePath, rcappsConfig.ignore)) {
                         return null;
                     }
@@ -105,8 +113,12 @@ function getTypescriptFilesFromProject(
 export async function getAppSource(path: string): Promise<IAppSource> {
     // Load .rcappsconfig if it exists
     const rcappsConfig = await readRcappsConfig(path);
-    
-    const directoryWalkData: ICompilerFile[] = await walkDirectory(path, path, rcappsConfig);
+
+    const directoryWalkData: ICompilerFile[] = await walkDirectory(
+        path,
+        path,
+        rcappsConfig,
+    );
     const projectFiles: ICompilerFile[] = filterProjectFiles(
         path,
         directoryWalkData,

--- a/src/misc/rcappsConfigReader.ts
+++ b/src/misc/rcappsConfigReader.ts
@@ -1,0 +1,101 @@
+import * as fs from "fs";
+import * as path from "path";
+import logger from "./logger";
+
+export interface IRcappsConfig {
+    ignore?: string[];
+    include?: string[];
+}
+
+/**
+ * Reads and parses the .rcappsconfig file from the given directory
+ * @param projectPath The path to the project directory
+ * @returns The parsed configuration or null if file doesn't exist
+ */
+export async function readRcappsConfig(projectPath: string): Promise<IRcappsConfig | null> {
+    const configPath = path.join(projectPath, ".rcappsconfig");
+    
+    try {
+        const configContent = await fs.promises.readFile(configPath, "utf8");
+        const config = JSON.parse(configContent) as IRcappsConfig;
+        
+        logger.debug(`Loaded .rcappsconfig from ${configPath}`);
+        return config;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            logger.debug("No .rcappsconfig file found, using default configuration");
+            return null;
+        }
+        
+        logger.warn(`Failed to parse .rcappsconfig file: ${error.message}`);
+        return null;
+    }
+}
+
+/**
+ * Merges the default ignore patterns with those from .rcappsconfig
+ * @param defaultIgnore Default ignore patterns
+ * @param config The .rcappsconfig configuration
+ * @returns Combined ignore patterns
+ */
+export function mergeIgnorePatterns(defaultIgnore: string[], config: IRcappsConfig | null): string[] {
+    if (!config || !config.ignore) {
+        return defaultIgnore;
+    }
+    
+    // Combine default ignore patterns with those from .rcappsconfig
+    // .rcappsconfig patterns take precedence (are added last)
+    return [...defaultIgnore, ...config.ignore];
+}
+
+/**
+ * Checks if a file path should be ignored based on the configuration
+ * @param filePath The file path to check
+ * @param ignorePatterns Array of ignore patterns (glob-style)
+ * @returns true if the file should be ignored
+ */
+export function shouldIgnoreFile(filePath: string, ignorePatterns: string[]): boolean {
+    return ignorePatterns.some(pattern => {
+        // Support both glob patterns and simple directory/file names
+        // Check for exact matches, basename matches, and path contains matches
+        const normalizedPath = path.normalize(filePath).replace(/\\/g, "/");
+        const normalizedPattern = pattern.replace(/\\/g, "/");
+        
+        // Simple pattern matching - check if the pattern matches the path
+        let isMatch = false;
+        
+        // Exact match
+        if (normalizedPath === normalizedPattern) {
+            isMatch = true;
+        }
+        // Basename match
+        else if (path.basename(normalizedPath) === normalizedPattern) {
+            isMatch = true;
+        }
+        // Path contains pattern
+        else if (normalizedPath.includes(normalizedPattern)) {
+            isMatch = true;
+        }
+        // Glob-style patterns
+        else if (normalizedPattern.includes("*") || normalizedPattern.includes("?")) {
+            // Convert simple glob pattern to regex
+            const regexPattern = normalizedPattern
+                .replace(/\./g, "\\.")
+                .replace(/\*/g, ".*")
+                .replace(/\?/g, ".");
+            try {
+                const regex = new RegExp(`^${regexPattern}$`);
+                isMatch = regex.test(normalizedPath) || regex.test(path.basename(normalizedPath));
+            } catch (e) {
+                // If regex fails, fall back to simple contains check
+                isMatch = normalizedPath.includes(normalizedPattern.replace(/\*/g, ""));
+            }
+        }
+        
+        if (isMatch) {
+            logger.debug(`File ${filePath} ignored by pattern: ${pattern}`);
+        }
+        
+        return isMatch;
+    });
+}

--- a/src/packager/AppPackager.ts
+++ b/src/packager/AppPackager.ts
@@ -13,7 +13,11 @@ import type {
 } from "../definition";
 import { isBundled } from "../bundler";
 import logger from "../misc/logger";
-import { readRcappsConfig, mergeIgnorePatterns, type IRcappsConfig } from "../misc/rcappsConfigReader";
+import {
+    readRcappsConfig,
+    mergeIgnorePatterns,
+    type IRcappsConfig,
+} from "../misc/rcappsConfigReader";
 
 export class AppPackager {
     public static DefaultIgnorePatterns: string[] = [
@@ -29,6 +33,7 @@ export class AppPackager {
     ];
 
     private zip = new Yazl.ZipFile();
+
     private rcappsConfig: IRcappsConfig | null = null;
 
     constructor(
@@ -46,7 +51,10 @@ export class AppPackager {
             this.rcappsConfig = await readRcappsConfig(this.fd.folder);
         }
 
-        const ignorePatterns = mergeIgnorePatterns(AppPackager.DefaultIgnorePatterns, this.rcappsConfig);
+        const ignorePatterns = mergeIgnorePatterns(
+            AppPackager.DefaultIgnorePatterns,
+            this.rcappsConfig,
+        );
 
         return {
             dot: false,
@@ -146,7 +154,7 @@ export class AppPackager {
     // tslint:disable-next-line:promise-function-async
     private async asyncGlob(): Promise<Array<string>> {
         const globOptions = await this.getGlobOptions();
-        
+
         return new Promise((resolve, reject) => {
             glob(this.fd.toZip, globOptions, (err, matches) => {
                 if (err) {

--- a/tests/integration/rcappsconfig-integration.spec.ts
+++ b/tests/integration/rcappsconfig-integration.spec.ts
@@ -1,0 +1,166 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import { getAppSource } from '../../src/compiler/getAppSource';
+import { AppPackager } from '../../src/packager/AppPackager';
+import { FolderDetails } from '../../src/misc/folderDetails';
+import type { ICompilerResult } from '../../src/definition';
+
+describe('RcappsConfig Integration Tests', () => {
+    let tempDir: string;
+    
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rcapps-integration-'));
+    });
+    
+    afterEach(() => {
+        // Clean up temp directory
+        if (fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('should exclude files specified in .rcappsconfig from source compilation', async () => {
+        // Create a mock app structure
+        const appJsonContent = {
+            id: 'test-app',
+            name: 'Test App',
+            version: '1.0.0',
+            classFile: 'main.ts',
+            requiredApiVersion: '^1.0.0'
+        };
+        
+        // Create app.json
+        fs.writeFileSync(
+            path.join(tempDir, 'app.json'),
+            JSON.stringify(appJsonContent, null, 2)
+        );
+        
+        // Create main TypeScript file
+        fs.writeFileSync(
+            path.join(tempDir, 'main.ts'),
+            `export class TestApp {
+                getName(): string {
+                    return 'Test App';
+                }
+            }`
+        );
+        
+        // Create a file that should be ignored
+        fs.writeFileSync(
+            path.join(tempDir, 'debug.ts'),
+            `export const DEBUG_INFO = 'This should be ignored';`
+        );
+        
+        // Create .rcappsconfig to ignore debug.ts
+        const rcappsConfig = {
+            ignore: ['debug.ts', '*.log']
+        };
+        fs.writeFileSync(
+            path.join(tempDir, '.rcappsconfig'),
+            JSON.stringify(rcappsConfig, null, 2)
+        );
+        
+        // Get app source and verify debug.ts is excluded
+        const appSource = await getAppSource(tempDir);
+        
+        const sourceFileNames = Object.keys(appSource.sourceFiles);
+        expect(sourceFileNames).to.include('main.ts');
+        expect(sourceFileNames).not.to.include('debug.ts');
+    });
+
+    it('should exclude files from packaging based on .rcappsconfig', async () => {
+        // Create a mock app structure
+        const appJsonContent = {
+            id: '12345678-1234-4567-8901-123456789012',
+            name: 'Test App',
+            nameSlug: 'test-app',
+            version: '1.0.0',
+            description: 'Test app for integration testing',
+            author: {
+                name: 'Test Author',
+                homepage: 'https://example.com',
+                support: 'https://example.com/support'
+            },
+            classFile: 'main.ts',
+            iconFile: 'icon.png',
+            requiredApiVersion: '^1.0.0'
+        };
+        
+        // Create app.json
+        fs.writeFileSync(
+            path.join(tempDir, 'app.json'),
+            JSON.stringify(appJsonContent, null, 2)
+        );
+        
+        // Create package.json (required for packaging)
+        fs.writeFileSync(
+            path.join(tempDir, 'package.json'),
+            JSON.stringify({ name: 'test-app', version: '1.0.0' }, null, 2)
+        );
+        
+        // Create icon file (referenced in app.json)
+        fs.writeFileSync(path.join(tempDir, 'icon.png'), 'fake png content');
+        
+        // Create main file
+        fs.writeFileSync(
+            path.join(tempDir, 'main.ts'),
+            'export class TestApp { getName(): string { return "Test App"; } }'
+        );
+        
+        // Create files that should be ignored
+        fs.writeFileSync(path.join(tempDir, 'debug.log'), 'debug information');
+        fs.writeFileSync(path.join(tempDir, 'temp-file.txt'), 'temporary data');
+        
+        // Create .rcappsconfig
+        const rcappsConfig = {
+            ignore: ['*.log', 'temp-*']
+        };
+        fs.writeFileSync(
+            path.join(tempDir, '.rcappsconfig'),
+            JSON.stringify(rcappsConfig, null, 2)
+        );
+        
+        // Test the glob options generation
+        const folderDetails = new FolderDetails(tempDir);
+        await folderDetails.readInfoFile();
+        
+        const mockCompilerResult: ICompilerResult = {
+            files: {
+                'main.ts': { 
+                    compiled: 'mock compiled content',
+                    name: 'main.ts',
+                    content: 'mock content',
+                    version: 0
+                }
+            },
+            diagnostics: [],
+            duration: 100,
+            implemented: [],
+            name: 'test-app',
+            version: '1.0.0',
+            typeScriptVersion: '5.0.0'
+        };
+        
+        const packager = new AppPackager(
+            { tool: 'test', version: '1.0.0' },
+            folderDetails,
+            mockCompilerResult,
+            path.join(tempDir, 'output.zip')
+        );
+        
+        // Access the private method for testing by casting to any
+        const globOptions = await (packager as any).getGlobOptions();
+        
+        // Verify that our custom ignore patterns are included
+        expect(globOptions.ignore).to.include('*.log');
+        expect(globOptions.ignore).to.include('temp-*');
+        
+        // Verify default patterns are still there
+        expect(globOptions.ignore).to.include('**/*.ts');
+        expect(globOptions.ignore).to.include('**/.*');
+    });
+});

--- a/tests/rcappsConfigReader.spec.ts
+++ b/tests/rcappsConfigReader.spec.ts
@@ -1,0 +1,128 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import { 
+    readRcappsConfig, 
+    mergeIgnorePatterns, 
+    shouldIgnoreFile, 
+    type IRcappsConfig 
+} from '../src/misc/rcappsConfigReader';
+
+describe('rcappsConfigReader', () => {
+    let tempDir: string;
+    
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rcapps-test-'));
+    });
+    
+    afterEach(() => {
+        // Clean up temp directory
+        if (fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    describe('readRcappsConfig', () => {
+        it('should return null when .rcappsconfig file does not exist', async () => {
+            const config = await readRcappsConfig(tempDir);
+            expect(config).to.be.null;
+        });
+
+        it('should parse valid .rcappsconfig file', async () => {
+            const configContent = {
+                ignore: ['*.log', 'temp/**', '.env']
+            };
+            
+            fs.writeFileSync(
+                path.join(tempDir, '.rcappsconfig'),
+                JSON.stringify(configContent)
+            );
+            
+            const config = await readRcappsConfig(tempDir);
+            expect(config).to.deep.equal(configContent);
+        });
+
+        it('should return null for invalid JSON in .rcappsconfig', async () => {
+            fs.writeFileSync(
+                path.join(tempDir, '.rcappsconfig'),
+                'invalid json content'
+            );
+            
+            const config = await readRcappsConfig(tempDir);
+            expect(config).to.be.null;
+        });
+    });
+
+    describe('mergeIgnorePatterns', () => {
+        it('should return default patterns when config is null', () => {
+            const defaultPatterns = ['*.ts', '*.js'];
+            const result = mergeIgnorePatterns(defaultPatterns, null);
+            expect(result).to.deep.equal(defaultPatterns);
+        });
+
+        it('should merge default and config patterns', () => {
+            const defaultPatterns = ['*.ts', '*.js'];
+            const config: IRcappsConfig = {
+                ignore: ['*.log', 'temp/**']
+            };
+            
+            const result = mergeIgnorePatterns(defaultPatterns, config);
+            expect(result).to.deep.equal(['*.ts', '*.js', '*.log', 'temp/**']);
+        });
+
+        it('should handle config without ignore property', () => {
+            const defaultPatterns = ['*.ts', '*.js'];
+            const config: IRcappsConfig = {};
+            
+            const result = mergeIgnorePatterns(defaultPatterns, config);
+            expect(result).to.deep.equal(defaultPatterns);
+        });
+    });
+
+    describe('shouldIgnoreFile', () => {
+        it('should match exact file paths', () => {
+            const patterns = ['src/test.ts', 'config.json'];
+            
+            expect(shouldIgnoreFile('src/test.ts', patterns)).to.be.true;
+            expect(shouldIgnoreFile('config.json', patterns)).to.be.true;
+            expect(shouldIgnoreFile('src/main.ts', patterns)).to.be.false;
+        });
+
+        it('should match basenames', () => {
+            const patterns = ['test.ts', 'config.json'];
+            
+            expect(shouldIgnoreFile('src/test.ts', patterns)).to.be.true;
+            expect(shouldIgnoreFile('deep/nested/config.json', patterns)).to.be.true;
+            expect(shouldIgnoreFile('src/main.ts', patterns)).to.be.false;
+        });
+
+        it('should match path contains', () => {
+            const patterns = ['node_modules', '.git'];
+            
+            expect(shouldIgnoreFile('node_modules/package/index.js', patterns)).to.be.true;
+            expect(shouldIgnoreFile('src/.git/config', patterns)).to.be.true;
+            expect(shouldIgnoreFile('src/main.ts', patterns)).to.be.false;
+        });
+
+        it('should match simple glob patterns', () => {
+            const patterns = ['*.log', '*.tmp', 'test*'];
+            
+            expect(shouldIgnoreFile('app.log', patterns)).to.be.true;
+            expect(shouldIgnoreFile('data.tmp', patterns)).to.be.true;
+            expect(shouldIgnoreFile('test-file.js', patterns)).to.be.true;
+            expect(shouldIgnoreFile('src/main.ts', patterns)).to.be.false;
+        });
+
+        it('should match directory patterns', () => {
+            const patterns = ['temp/**', 'build/*'];
+            
+            expect(shouldIgnoreFile('temp/file.txt', patterns)).to.be.true;
+            expect(shouldIgnoreFile('temp/nested/file.txt', patterns)).to.be.true;
+            expect(shouldIgnoreFile('build/output.js', patterns)).to.be.true;
+            expect(shouldIgnoreFile('src/main.ts', patterns)).to.be.false;
+        });
+    });
+});


### PR DESCRIPTION
Add support for `.rcappsconfig` files to allow users to explicitly ignore files from compilation and packaging.

---
<a href="https://cursor.com/background-agent?bcId=bc-01b4c1ea-f831-402c-bbbe-ccb6f42f63f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01b4c1ea-f831-402c-bbbe-ccb6f42f63f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

