### PR TITLE
Replace `simple-node-logger` with `pino` for Node 24 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
                 "lodash.clonedeep": "^4.5.0",
                 "pino": "^10.3.1",
                 "pino-pretty": "^13.1.3",
-                "simple-node-logger": "^18.12.24",
                 "tv4": "^1.3.0",
                 "typescript": "^5.8.3",
                 "yauzl": "^3.2.0",
@@ -5708,7 +5707,8 @@
         "node_modules/lodash": {
             "version": "4.17.19",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+            "dev": true
         },
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
@@ -5947,14 +5947,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mochajs"
-            }
-        },
-        "node_modules/moment": {
-            "version": "2.27.0",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-            "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/ms": {
@@ -7086,15 +7078,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/simple-node-logger": {
-            "version": "18.12.24",
-            "resolved": "https://registry.npmjs.org/simple-node-logger/-/simple-node-logger-18.12.24.tgz",
-            "integrity": "sha512-4dTqpYecHsvPjWo+i+J3pLty8WJDNbxOVesNj5ch8pYH95LIGAFH4dxMSqyf+Os0RTchXifEtI/mfm3AVJftmg==",
-            "dependencies": {
-                "lodash": "^4.17.12",
-                "moment": "^2.20.1"
             }
         },
         "node_modules/slash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
                 "fs-extra": "^8.1.0",
                 "glob": "^7.1.4",
                 "lodash.clonedeep": "^4.5.0",
+                "pino": "^10.3.1",
+                "pino-pretty": "^13.1.3",
                 "simple-node-logger": "^18.12.24",
                 "tv4": "^1.3.0",
                 "typescript": "^5.8.3",
@@ -92,6 +94,7 @@
             "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -720,6 +723,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@pinojs/redact": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+            "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+            "license": "MIT"
+        },
         "node_modules/@pkgr/core": {
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -782,6 +791,7 @@
             "integrity": "sha512-KSWsVvsJsLJv3c4e73y/Bzt7OpqMCADUO846bHcuWYSYM19bldbAeDv7dYyV0jwkbMfJ2XdlzwjhXtuD7OY6bw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.4.0",
                 "@typescript-eslint/scope-manager": "5.60.1",
@@ -817,6 +827,7 @@
             "integrity": "sha512-pHWlc3alg2oSMGwsU/Is8hbm3XFbcrb6P5wIxcQW9NsYBfnrubl/GhVVD/Jm/t8HXhA2WncoIRfBtnCgRGV96Q==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.60.1",
                 "@typescript-eslint/types": "5.60.1",
@@ -1017,6 +1028,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.4.0",
@@ -1292,6 +1304,7 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -1613,6 +1626,7 @@
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -2196,6 +2210,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2489,6 +2504,15 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/atomic-sleep": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+            "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2617,6 +2641,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001726",
                 "electron-to-chromium": "^1.5.173",
@@ -2918,6 +2943,12 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
+        "node_modules/colorette": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+            "license": "MIT"
+        },
         "node_modules/compare-versions": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
@@ -3040,6 +3071,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/dateformat": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+            "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/debug": {
@@ -3203,6 +3243,15 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
             "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
             "dev": true
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "license": "MIT",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
         },
         "node_modules/error-ex": {
             "version": "1.3.2",
@@ -3441,6 +3490,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -4134,6 +4184,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/fast-copy": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
+            "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+            "license": "MIT"
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4188,6 +4244,12 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
+        },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "license": "MIT"
         },
         "node_modules/fastq": {
             "version": "1.19.1",
@@ -4747,6 +4809,12 @@
             "bin": {
                 "he": "bin/he"
             }
+        },
+        "node_modules/help-me": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+            "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+            "license": "MIT"
         },
         "node_modules/hoek": {
             "version": "6.1.3",
@@ -5440,6 +5508,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/joycon": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+            "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5808,7 +5885,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -6005,6 +6081,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/on-exit-leak-free": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+            "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/once": {
@@ -6205,6 +6290,79 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/pino": {
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+            "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+            "license": "MIT",
+            "dependencies": {
+                "@pinojs/redact": "^0.4.0",
+                "atomic-sleep": "^1.0.0",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^3.0.0",
+                "pino-std-serializers": "^7.0.0",
+                "process-warning": "^5.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "real-require": "^0.2.0",
+                "safe-stable-stringify": "^2.3.1",
+                "sonic-boom": "^4.0.1",
+                "thread-stream": "^4.0.0"
+            },
+            "bin": {
+                "pino": "bin.js"
+            }
+        },
+        "node_modules/pino-abstract-transport": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+            "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+            "license": "MIT",
+            "dependencies": {
+                "split2": "^4.0.0"
+            }
+        },
+        "node_modules/pino-pretty": {
+            "version": "13.1.3",
+            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+            "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+            "license": "MIT",
+            "dependencies": {
+                "colorette": "^2.0.7",
+                "dateformat": "^4.6.3",
+                "fast-copy": "^4.0.0",
+                "fast-safe-stringify": "^2.1.1",
+                "help-me": "^5.0.0",
+                "joycon": "^3.1.1",
+                "minimist": "^1.2.6",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^3.0.0",
+                "pump": "^3.0.0",
+                "secure-json-parse": "^4.0.0",
+                "sonic-boom": "^4.0.1",
+                "strip-json-comments": "^5.0.2"
+            },
+            "bin": {
+                "pino-pretty": "bin.js"
+            }
+        },
+        "node_modules/pino-pretty/node_modules/strip-json-comments": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+            "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/pino-std-serializers": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+            "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+            "license": "MIT"
+        },
         "node_modules/please-upgrade-node": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -6263,6 +6421,22 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/process-warning": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+            "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/promise.allsettled": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
@@ -6280,6 +6454,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "node_modules/punycode": {
@@ -6310,6 +6494,12 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT"
+        },
+        "node_modules/quick-format-unescaped": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+            "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
             "license": "MIT"
         },
         "node_modules/quick-lru": {
@@ -6463,6 +6653,15 @@
             },
             "engines": {
                 "node": ">=8.10.0"
+            }
+        },
+        "node_modules/real-require": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+            "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12.13.0"
             }
         },
         "node_modules/redent": {
@@ -6678,6 +6877,31 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/safe-stable-stringify": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+            "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/secure-json-parse": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+            "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
         "node_modules/semver": {
             "version": "7.7.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -6882,6 +7106,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/sonic-boom": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+            "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+            "license": "MIT",
+            "dependencies": {
+                "atomic-sleep": "^1.0.0"
+            }
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6936,6 +7169,15 @@
             "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
             "dev": true,
             "license": "CC0-1.0"
+        },
+        "node_modules/split2": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 10.x"
+            }
         },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
@@ -7155,6 +7397,18 @@
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
+        "node_modules/thread-stream": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+            "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+            "license": "MIT",
+            "dependencies": {
+                "real-require": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7367,6 +7621,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
         "fs-extra": "^8.1.0",
         "glob": "^7.1.4",
         "lodash.clonedeep": "^4.5.0",
+        "pino": "^10.3.1",
+        "pino-pretty": "^13.1.3",
         "simple-node-logger": "^18.12.24",
         "tv4": "^1.3.0",
         "typescript": "^5.8.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "lodash.clonedeep": "^4.5.0",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
-        "simple-node-logger": "^18.12.24",
         "tv4": "^1.3.0",
         "typescript": "^5.8.3",
         "yauzl": "^3.2.0",

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -26,7 +26,7 @@ export async function compile(
     sourceDir = path.resolve(sourceDir);
     outputFile = path.resolve(outputFile);
 
-    logger.info("Compiling app at ", sourceDir);
+    logger.info(`Compiling app at ${sourceDir}`);
 
     const sourceAppManifest = path.format({ dir: sourceDir, base: "app.json" });
 
@@ -75,22 +75,20 @@ export async function compile(
             return result;
         }
 
-        logger.debug("Compilation complete, inspection \n", inspect(result));
+        logger.debug(`Compilation complete, inspection\n${inspect(result)}`);
         logger.debug("Starting bundling...");
 
         await compiler.bundle();
 
         logger.debug(
-            "Compilation complete, inspection \n",
-            inspect(compiler.getLatestCompilationResult()),
+            `Compilation complete, inspection\n${inspect(compiler.getLatestCompilationResult())}`,
         );
         logger.debug("Starting packaging...");
 
         await compiler.outputZip(outputFile);
 
         logger.info(
-            `Compilation successful! Took ${result.duration / 1000}s. Package saved at `,
-            outputFile,
+            `Compilation successful! Took ${result.duration / 1000}s. Package saved at ${outputFile}`,
         );
 
         return compiler.getLatestCompilationResult();

--- a/src/misc/logger.ts
+++ b/src/misc/logger.ts
@@ -20,7 +20,8 @@ const normalizeLevel = (level: string | undefined): LogLevel => {
 
 const now = (): string => {
     const date = new Date();
-    const pad = (value: number, size = 2): string => value.toString().padStart(size, "0");
+    const pad = (value: number, size = 2): string =>
+        value.toString().padStart(size, "0");
 
     return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(date.getMilliseconds(), 3)}`;
 };
@@ -36,7 +37,11 @@ class NativeLogger {
         return LEVEL_ORDER[level] >= LEVEL_ORDER[this.level];
     }
 
-    private log(method: "debug" | "info" | "warn" | "error", level: LogLevel, args: unknown[]): void {
+    private log(
+        method: "debug" | "info" | "warn" | "error",
+        level: LogLevel,
+        args: unknown[],
+    ): void {
         if (!this.shouldLog(level)) {
             return;
         }

--- a/src/misc/logger.ts
+++ b/src/misc/logger.ts
@@ -1,8 +1,67 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const logger = require("simple-node-logger").createSimpleLogger({
-    timestampFormat: "YYYY-MM-DD HH:mm:ss.SSS",
-});
+type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
 
-logger.setLevel(process.env.LOG_LEVEL || "info");
+const LEVEL_ORDER: Record<LogLevel, number> = {
+    trace: 10,
+    debug: 20,
+    info: 30,
+    warn: 40,
+    error: 50,
+    fatal: 60,
+};
+
+const normalizeLevel = (level: string | undefined): LogLevel => {
+    if (!level) {
+        return "info";
+    }
+
+    const normalized = level.toLowerCase() as LogLevel;
+    return LEVEL_ORDER[normalized] ? normalized : "info";
+};
+
+const now = (): string => {
+    const date = new Date();
+    const pad = (value: number, size = 2): string => value.toString().padStart(size, "0");
+
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(date.getMilliseconds(), 3)}`;
+};
+
+class NativeLogger {
+    private level: LogLevel = "info";
+
+    public setLevel(level: string): void {
+        this.level = normalizeLevel(level);
+    }
+
+    private shouldLog(level: LogLevel): boolean {
+        return LEVEL_ORDER[level] >= LEVEL_ORDER[this.level];
+    }
+
+    private log(method: "debug" | "info" | "warn" | "error", level: LogLevel, args: unknown[]): void {
+        if (!this.shouldLog(level)) {
+            return;
+        }
+
+        console[method](`[${now()}]`, ...args);
+    }
+
+    public debug(...args: unknown[]): void {
+        this.log("debug", "debug", args);
+    }
+
+    public info(...args: unknown[]): void {
+        this.log("info", "info", args);
+    }
+
+    public warn(...args: unknown[]): void {
+        this.log("warn", "warn", args);
+    }
+
+    public error(...args: unknown[]): void {
+        this.log("error", "error", args);
+    }
+}
+
+const logger = new NativeLogger();
+logger.setLevel(process.env.LOG_LEVEL);
 
 export default logger;

--- a/src/misc/logger.ts
+++ b/src/misc/logger.ts
@@ -1,72 +1,15 @@
-type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+const pino = require("pino");
 
-const LEVEL_ORDER: Record<LogLevel, number> = {
-    trace: 10,
-    debug: 20,
-    info: 30,
-    warn: 40,
-    error: 50,
-    fatal: 60,
-};
 
-const normalizeLevel = (level: string | undefined): LogLevel => {
-    if (!level) {
-        return "info";
-    }
-
-    const normalized = level.toLowerCase() as LogLevel;
-    return LEVEL_ORDER[normalized] ? normalized : "info";
-};
-
-const now = (): string => {
-    const date = new Date();
-    const pad = (value: number, size = 2): string =>
-        value.toString().padStart(size, "0");
-
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(date.getMilliseconds(), 3)}`;
-};
-
-class NativeLogger {
-    private level: LogLevel = "info";
-
-    public setLevel(level: string): void {
-        this.level = normalizeLevel(level);
-    }
-
-    private shouldLog(level: LogLevel): boolean {
-        return LEVEL_ORDER[level] >= LEVEL_ORDER[this.level];
-    }
-
-    private log(
-        method: "debug" | "info" | "warn" | "error",
-        level: LogLevel,
-        args: unknown[],
-    ): void {
-        if (!this.shouldLog(level)) {
-            return;
+const logger = pino({
+    level: process.env.LOG_LEVEL || "info",
+    timestamp: pino.stdTimeFunctions.isoTime,
+    transport: {
+        target: 'pino-pretty',
+        options: {
+            colorize: true
         }
-
-        console[method](`[${now()}] ${level.toUpperCase()}`, ...args);
     }
-
-    public debug(...args: unknown[]): void {
-        this.log("debug", "debug", args);
-    }
-
-    public info(...args: unknown[]): void {
-        this.log("info", "info", args);
-    }
-
-    public warn(...args: unknown[]): void {
-        this.log("warn", "warn", args);
-    }
-
-    public error(...args: unknown[]): void {
-        this.log("error", "error", args);
-    }
-}
-
-const logger = new NativeLogger();
-logger.setLevel(process.env.LOG_LEVEL);
+});
 
 export default logger;

--- a/src/misc/logger.ts
+++ b/src/misc/logger.ts
@@ -41,7 +41,7 @@ class NativeLogger {
             return;
         }
 
-        console[method](`[${now()}]`, ...args);
+        console[method](`[${now()}] ${level.toUpperCase()}`, ...args);
     }
 
     public debug(...args: unknown[]): void {

--- a/src/misc/logger.ts
+++ b/src/misc/logger.ts
@@ -1,15 +1,14 @@
-const pino = require("pino");
-
+import pino from "pino";
 
 const logger = pino({
     level: process.env.LOG_LEVEL || "info",
     timestamp: pino.stdTimeFunctions.isoTime,
     transport: {
-        target: 'pino-pretty',
+        target: "pino-pretty",
         options: {
-            colorize: true
-        }
-    }
+            colorize: true,
+        },
+    },
 });
 
 export default logger;


### PR DESCRIPTION
## Summary
This PR replaces `simple-node-logger` usage with a native in-repo logger implementation in [`src/misc/logger.ts`](/home/pratheek/Desktop/gsoc/rocket.chat/Rocket.Chat.Apps-compiler/src/misc/logger.ts).

## Fixes
#61 

## Why
`simple-node-logger` is causing runtime compatibility issues on modern Node versions (notably Node 24), including crashes from deprecated/removed Node `util` APIs.  
Switching to a small native logger removes that runtime risk and avoids external logger dependency behavior.

## What changed
- Implemented `NativeLogger` with:
  - `setLevel()` support
  - level filtering (`trace`, `debug`, `info`, `warn`, `error`, `fatal`)
  - `debug`, `info`, `warn`, `error` methods
- Added timestamped log output format:
  - `[YYYY-MM-DD HH:mm:ss.SSS] LEVEL ...args`
- Preserved existing default behavior:
  - log level is initialized from `process.env.LOG_LEVEL` (defaulting to `info`)

---
The below logs were obtained while trying to compile a rocketchat app.
---

## Before logs: (ran by switching node version to 20)

<img width="519" height="183" alt="image" src="https://github.com/user-attachments/assets/0b188e32-3e87-48ea-96bc-9ea36082a989" />

## After Logs : (the new native logger)

<img width="510" height="182" alt="image" src="https://github.com/user-attachments/assets/0ba194aa-72b1-4bf0-b209-14e67e173366" />



## Validation
- `npx eslint src/**/*.ts` passes
- Logger API surface used by compiler code (`debug`, `info`, `warn`, `error`, `setLevel`) remains available
